### PR TITLE
fix(CVEs): update base image and fixes High and Critical CVEs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,30 +4,43 @@ on:
   release:
     types: [published]
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}    
+
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@3d58c274f17dffee475a5520cbe67f0a882c4dbb
+
+      - name: Log in to the container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: domnikl/schema-registry-gitops
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@4976231911ebf5f32aad765192d35f942aa48cb8
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine AS tester
+FROM amazoncorretto:17-alpine AS tester
 
 WORKDIR /home/cuser
 
@@ -11,7 +11,7 @@ RUN ./gradlew --no-daemon check
 FROM tester AS builder
 RUN ./gradlew --no-daemon shadowJar
 
-FROM openjdk:17-alpine AS distribution
+FROM amazoncorretto:17-alpine AS distribution
 COPY --from=builder /home/cuser/build/libs/schema-registry-gitops.jar /home/cuser/schema-registry-gitops.jar
 
 WORKDIR /home/cuser

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+Forked to fix CVEs
+
+
 # schema-registry-gitops
 
 [![build](https://github.com/domnikl/schema-registry-gitops/workflows/build/badge.svg)](https://github.com/domnikl/schema-registry-gitops/actions)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,10 +35,18 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.16.1")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.16.1")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.16.1")
+    constraints {
+        implementation("com.google.code.gson:gson:2.8.9") {
+            because("CVE-2022-25647")
+        }
+        implementation("org.apache.commons:commons-compress:1.24.0") {
+            because("CVE-2023-42503")
+        }
+    }
 
-    implementation("io.confluent:kafka-schema-registry-client:7.4.0")
-    implementation("io.confluent:kafka-protobuf-serializer:7.4.0")
-    implementation("io.confluent:kafka-json-schema-serializer:7.4.0")
+    implementation("io.confluent:kafka-schema-registry-client:7.6.0")
+    implementation("io.confluent:kafka-protobuf-serializer:7.6.0")
+    implementation("io.confluent:kafka-json-schema-serializer:7.6.0")
     implementation("com.github.everit-org.json-schema:org.everit.json.schema:1.14.4")
 
     implementation("io.github.java-diff-utils:java-diff-utils:4.12")


### PR DESCRIPTION
use amazon corretto base image and fixes a few dependencies version in order to remove Critical and High CVEs as of today.
```
docker-scout quickview docker.io/talend/schema-registry-gitops:latest3
    ✓ SBOM of image already cached, 76 packages indexed

  Target             │  talend/schema-registry-gitops:latest3  │    0C     0H     0M     0L   
    digest           │  2bf6a24c016c                           │                              
  Base image         │  amazoncorretto:17-alpine               │    0C     0H     0M     0L   
  Updated base image │  amazoncorretto:21-alpine3.16           │    0C     0H     0M     0L
 ```